### PR TITLE
Feat: 상품 거래 비밀번호 변경 기능 구현

### DIFF
--- a/src/main/java/com/unity/goods/domain/member/controller/MemberController.java
+++ b/src/main/java/com/unity/goods/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.unity.goods.domain.member.controller;
 
 import static com.unity.goods.domain.member.dto.ChangePasswordDto.ChangePasswordRequest;
+import static com.unity.goods.domain.member.dto.ChangeTradePasswordDto.ChangeTradePasswordRequest;
 import static com.unity.goods.domain.member.dto.FindPasswordDto.FindPasswordRequest;
 
 import com.unity.goods.domain.member.dto.LoginDto;
@@ -103,6 +104,14 @@ public class MemberController {
       @AuthenticationPrincipal UserDetailsImpl member,
       @RequestBody @Valid ChangePasswordRequest changePasswordRequest) {
     memberService.changePassword(changePasswordRequest, member);
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping("/trade-password")
+  public ResponseEntity<?> changeTradePassword(
+      @AuthenticationPrincipal UserDetailsImpl member,
+      @RequestBody @Valid ChangeTradePasswordRequest changeTradePasswordRequest) {
+    memberService.changeTradePassword(changeTradePasswordRequest, member);
     return ResponseEntity.ok().build();
   }
 

--- a/src/main/java/com/unity/goods/domain/member/dto/ChangeTradePasswordDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/ChangeTradePasswordDto.java
@@ -1,0 +1,24 @@
+package com.unity.goods.domain.member.dto;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class ChangeTradePasswordDto {
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class ChangeTradePasswordRequest {
+
+    @Pattern(regexp = "^[0-9]{6}$", message = "거래 비밀번호는 6자리 숫자로 작성해주세요.")
+    private String curTradePassword;
+
+    @Pattern(regexp = "^[0-9]{6}$", message = "거래 비밀번호는 6자리 숫자로 작성해주세요.")
+    private String newTradePassword;
+
+  }
+}

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -335,7 +335,7 @@ public class MemberService {
     Member findMember = memberRepository.findByEmail(member.getUsername())
         .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
-    if (passwordEncoder.matches(changePasswordRequest.getCurPassword(), member.getPassword())) {
+    if (!passwordEncoder.matches(changePasswordRequest.getCurPassword(), member.getPassword())) {
       throw new MemberException(PASSWORD_NOT_MATCH);
     }
 

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -17,6 +17,7 @@ import static com.unity.goods.global.exception.ErrorCode.USE_SOCIAL_LOGIN;
 import com.unity.goods.domain.email.exception.EmailException;
 import com.unity.goods.domain.email.type.EmailSubjects;
 import com.unity.goods.domain.member.dto.ChangePasswordDto.ChangePasswordRequest;
+import com.unity.goods.domain.member.dto.ChangeTradePasswordDto.ChangeTradePasswordRequest;
 import com.unity.goods.domain.member.dto.FindPasswordDto.FindPasswordRequest;
 import com.unity.goods.domain.member.dto.LoginDto;
 import com.unity.goods.domain.member.dto.MemberProfileDto.MemberProfileResponse;
@@ -343,5 +344,23 @@ public class MemberService {
     }
 
     findMember.changePassword(passwordEncoder.encode(changePasswordRequest.getNewPassword()));
+  }
+
+  // 거래 비밀번호 변경
+  @Transactional
+  public void changeTradePassword(ChangeTradePasswordRequest changeTradePasswordRequest,
+      UserDetailsImpl member) {
+    Member findMember = memberRepository.findByEmail(member.getUsername())
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    if (!passwordEncoder.matches(changeTradePasswordRequest.getCurTradePassword(), findMember.getTradePassword())) {
+      throw new MemberException(PASSWORD_NOT_MATCH);
+    }
+
+    if (passwordEncoder.matches(changeTradePasswordRequest.getNewTradePassword(), findMember.getTradePassword())) {
+      throw new MemberException(CURRENT_USED_PASSWORD);
+    }
+
+    findMember.setTradePassword(passwordEncoder.encode(changeTradePasswordRequest.getNewTradePassword()));
   }
 }

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -96,6 +96,8 @@ public class SecurityConfig {
     List<RequestMatcher> requestMatchers = List.of(
         antMatcher(POST, "/api/member/logout"), // 로그아웃
         antMatcher(PUT, "/api/member/resign"), // 회원탈퇴
+        antMatcher(PUT, "/api/member/password"), // 비밀번호 변경
+        antMatcher(PUT, "/api/member/trade-password"), // 거래 비밀번호 변경
         antMatcher(POST, "/api/goods/new"),
         antMatcher("/api/goods/**")
     );

--- a/src/test/java/com/unity/goods/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/unity/goods/domain/member/service/MemberServiceTest.java
@@ -279,6 +279,8 @@ class MemberServiceTest {
     given(memberRepository.findByEmail(anyString()))
         .willReturn(Optional.of(member));
     given(passwordEncoder.encode(changePasswordRequest.getNewPassword())).willReturn("new1234");
+    given(!passwordEncoder.matches(changePasswordRequest.getCurPassword(),
+        member.getPassword())).willReturn(true);
 
     //when
     memberService.changePassword(changePasswordRequest, userDetails);
@@ -310,7 +312,10 @@ class MemberServiceTest {
 
     given(memberRepository.findByEmail(anyString()))
         .willReturn(Optional.of(member));
-    given(passwordEncoder.encode(changeTradePasswordRequest.getNewTradePassword())).willReturn("222222");
+    given(passwordEncoder.encode(changeTradePasswordRequest.getNewTradePassword())).willReturn(
+        "222222");
+    given(!passwordEncoder.matches(changeTradePasswordRequest.getCurTradePassword(),
+        member.getTradePassword())).willReturn(true);
 
     //when
     memberService.changeTradePassword(changeTradePasswordRequest, userDetails);

--- a/src/test/java/com/unity/goods/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/unity/goods/domain/member/service/MemberServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.unity.goods.domain.member.dto.ChangePasswordDto.ChangePasswordRequest;
+import com.unity.goods.domain.member.dto.ChangeTradePasswordDto.ChangeTradePasswordRequest;
 import com.unity.goods.domain.member.dto.FindPasswordDto.FindPasswordRequest;
 import com.unity.goods.domain.member.dto.MemberProfileDto.MemberProfileResponse;
 import com.unity.goods.domain.member.dto.ResignDto.ResignRequest;
@@ -284,6 +285,38 @@ class MemberServiceTest {
 
     //then
     assertEquals(member.getPassword(), "new1234");
+  }
+
+  @Test
+  @DisplayName("거래 비밀번호 변경 테스트")
+  void changeTradePasswordTest() {
+    //given
+    Member member = Member.builder()
+        .email("test@naver.com")
+        .password("test1234")
+        .tradePassword("111111")
+        .nickname("test")
+        .status(RESIGN)
+        .phoneNumber("010-1111-1111")
+        .profileImage("http://amazonS3/test.jpg")
+        .build();
+
+    ChangeTradePasswordRequest changeTradePasswordRequest = ChangeTradePasswordRequest.builder()
+        .curTradePassword("111111")
+        .newTradePassword("222222")
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(member);
+
+    given(memberRepository.findByEmail(anyString()))
+        .willReturn(Optional.of(member));
+    given(passwordEncoder.encode(changeTradePasswordRequest.getNewTradePassword())).willReturn("222222");
+
+    //when
+    memberService.changeTradePassword(changeTradePasswordRequest, userDetails);
+
+    //then
+    assertEquals(member.getTradePassword(), "222222");
   }
 
 


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 테스트 추가, 테스트 리팩토링

### 반영 브랜치
-  feat/goods-trade-password -> feat/goods

### 변경 사항
- 회원이 본인의 거래 비밀번호를 변경하는 기능을 추가했습니다.
- MemberController의 changeTradePassword에서 Requset로 현재 거래 비밀번호와 새로운 거래 비밀번호를 받아옵니다.
- MemberService의 changeTradePassword 메서드에서 거래 비밀번호를 변경합니다.
- 회원의 인가 정보를 사용하여 DB에서 회원을 가져온 후 요청받은 거래 비밀번호가 현재 거래 비밀번호와 일치하는지 검증합니다.
- 회원이 요청한 새로운 비밀번호가 현재 비밀번호와 일치하는지를 검증하여 동일하다면 예외를 발생시킵니다.
- Validation Checking이 완료되면 JPA 변경감지를 사용하여 회원의 거래 비밀번호를 변경합니다.
- 같은 로직을 사용하는 changePassword에서 비밀번호를 검증하는 로직에 오류가 있어 함께 수정했습니다.
- 비밀번호 변경과 거래 비밀번호 변경 기능을 테스트하였습니다.

### PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)