### PR TITLE
Feat: 상품 구매목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
+++ b/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
@@ -6,6 +6,7 @@ import com.unity.goods.domain.goods.dto.UploadGoodsDto.UploadGoodsRequest;
 import com.unity.goods.domain.goods.type.GoodsStatus;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.model.BaseEntity;
+import com.unity.goods.domain.trade.entity.Trade;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -71,6 +72,9 @@ public class Goods extends BaseEntity {
   @OneToMany(mappedBy = "goods")
   @Builder.Default
   private List<Image> imageList = new ArrayList<>();
+
+  @OneToMany(mappedBy = "goods")
+  private List<Trade> tradeList  = new ArrayList<>();
 
   public static Goods fromUploadGoodsRequest(UploadGoodsRequest request) {
     return Goods.builder()

--- a/src/main/java/com/unity/goods/domain/member/entity/Member.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Member.java
@@ -11,6 +11,7 @@ import com.unity.goods.domain.member.type.Role;
 import com.unity.goods.domain.member.type.SocialType;
 import com.unity.goods.domain.member.type.Status;
 import com.unity.goods.domain.model.BaseEntity;
+import com.unity.goods.domain.trade.entity.Trade;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -69,6 +70,9 @@ public class Member extends BaseEntity {
   @OneToMany(mappedBy = "member")
   @Builder.Default
   private List<Goods> goodsList = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member")
+  private List<Trade> tradeList  = new ArrayList<>();
 
   public static Member fromSignUpRequest(SignUpRequest signUpRequest, String imageUrl) {
 

--- a/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
+++ b/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
@@ -1,0 +1,33 @@
+package com.unity.goods.domain.trade.controller;
+
+import com.unity.goods.domain.trade.dto.PurchasedListDto.PurchasedListResponse;
+import com.unity.goods.domain.trade.service.TradeService;
+import com.unity.goods.global.jwt.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/trade")
+public class TradeController {
+
+  private final TradeService tradeService;
+
+  @GetMapping("/purchased-list")
+  public ResponseEntity<?> purchasedGoodsList(
+      @AuthenticationPrincipal UserDetailsImpl member,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+
+    Page<PurchasedListResponse> purchasedList
+        = tradeService.getPurchasedList(member, page, size);
+
+    return ResponseEntity.ok(purchasedList);
+  }
+}

--- a/src/main/java/com/unity/goods/domain/trade/dto/PurchasedListDto.java
+++ b/src/main/java/com/unity/goods/domain/trade/dto/PurchasedListDto.java
@@ -1,0 +1,22 @@
+package com.unity.goods.domain.trade.dto;
+
+import com.unity.goods.domain.goods.type.GoodsStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PurchasedListDto {
+
+  @Getter
+  @Builder
+  public static class PurchasedListResponse {
+
+    private Long goodsId;
+    private String sellerName;
+    private String goodsName;
+    private String price;
+    private String goodsThumbnail;
+    private GoodsStatus goodsStatus;
+    private Long tradedBefore;
+
+  }
+}

--- a/src/main/java/com/unity/goods/domain/trade/dto/PurchasedListDto.java
+++ b/src/main/java/com/unity/goods/domain/trade/dto/PurchasedListDto.java
@@ -10,6 +10,7 @@ public class PurchasedListDto {
   @Builder
   public static class PurchasedListResponse {
 
+    private Long memberId;
     private Long goodsId;
     private String sellerName;
     private String goodsName;

--- a/src/main/java/com/unity/goods/domain/trade/entity/Trade.java
+++ b/src/main/java/com/unity/goods/domain/trade/entity/Trade.java
@@ -1,0 +1,60 @@
+package com.unity.goods.domain.trade.entity;
+
+import com.unity.goods.domain.goods.entity.Goods;
+import com.unity.goods.domain.member.entity.Member;
+import com.unity.goods.domain.trade.type.TradePurpose;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Trade {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "trade_id")
+  private Long id;
+
+  @Column(nullable = false)
+  private Long tradePoint;
+
+  @CreatedDate
+  @Column(updatable = false, nullable = false)
+  private LocalDateTime tradedAt;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private TradePurpose tradePurpose;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "goods_id")
+  private Goods goods;
+
+}

--- a/src/main/java/com/unity/goods/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/unity/goods/domain/trade/exception/TradeException.java
@@ -1,0 +1,10 @@
+package com.unity.goods.domain.trade.exception;
+
+import com.unity.goods.global.exception.CustomException;
+import com.unity.goods.global.exception.ErrorCode;
+
+public class TradeException extends CustomException {
+  public TradeException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}

--- a/src/main/java/com/unity/goods/domain/trade/repository/TradeRepository.java
+++ b/src/main/java/com/unity/goods/domain/trade/repository/TradeRepository.java
@@ -1,0 +1,17 @@
+package com.unity.goods.domain.trade.repository;
+
+import com.unity.goods.domain.trade.entity.Trade;
+import com.unity.goods.domain.trade.type.TradePurpose;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+
+  @EntityGraph(attributePaths = {"goods", "goods.member"})
+  Page<Trade> findByMemberIdAndTradePurpose(Long memberId, TradePurpose tradePurpose,
+      Pageable pageable);
+}

--- a/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
+++ b/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
@@ -38,6 +38,7 @@ public class TradeService {
               goods.getImageList().isEmpty() ? null : goods.getImageList().get(0).getImageUrl();
 
           return PurchasedListResponse.builder()
+              .memberId(member.getId())
               .goodsId(goods.getId())
               .sellerName(goods.getMember().getNickname())
               .goodsName(goods.getGoodsName())

--- a/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
+++ b/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
@@ -1,0 +1,57 @@
+package com.unity.goods.domain.trade.service;
+
+import static com.unity.goods.domain.trade.type.TradePurpose.BUY;
+
+import com.unity.goods.domain.goods.entity.Goods;
+import com.unity.goods.domain.trade.dto.PurchasedListDto.PurchasedListResponse;
+import com.unity.goods.domain.trade.entity.Trade;
+import com.unity.goods.domain.trade.repository.TradeRepository;
+import com.unity.goods.global.jwt.UserDetailsImpl;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TradeService {
+
+  private final TradeRepository tradeRepository;
+
+  public Page<PurchasedListResponse> getPurchasedList(UserDetailsImpl member, int page, int size) {
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by("tradedAt").descending());
+    Page<Trade> purchasedPage = tradeRepository.findByMemberIdAndTradePurpose(
+        member.getId(), BUY, pageable);
+
+    List<PurchasedListResponse> purchasedList = purchasedPage.getContent().stream()
+        .map(trade -> {
+          Goods goods = trade.getGoods();
+          String imageUrl =
+              goods.getImageList().isEmpty() ? null : goods.getImageList().get(0).getImageUrl();
+
+          return PurchasedListResponse.builder()
+              .goodsId(goods.getId())
+              .sellerName(goods.getMember().getNickname())
+              .goodsName(goods.getGoodsName())
+              .price(String.valueOf(goods.getPrice()))
+              .goodsThumbnail(imageUrl)
+              .goodsStatus(goods.getGoodsStatus())
+              .tradedBefore(getTradedBeforeSeconds(trade.getTradedAt()))
+              .build();
+        }).collect(Collectors.toList());
+
+    return new PageImpl<>(purchasedList, pageable, purchasedPage.getTotalElements());
+  }
+
+  private static long getTradedBeforeSeconds(LocalDateTime tradedDateTime) {
+    return Duration.between(tradedDateTime, LocalDateTime.now()).getSeconds();
+  }
+}

--- a/src/main/java/com/unity/goods/domain/trade/type/TradePurpose.java
+++ b/src/main/java/com/unity/goods/domain/trade/type/TradePurpose.java
@@ -1,0 +1,5 @@
+package com.unity.goods.domain.trade.type;
+
+public enum TradePurpose {
+  BUY, SELL
+}

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -99,7 +99,8 @@ public class SecurityConfig {
         antMatcher(PUT, "/api/member/password"), // 비밀번호 변경
         antMatcher(PUT, "/api/member/trade-password"), // 거래 비밀번호 변경
         antMatcher(POST, "/api/goods/new"),
-        antMatcher("/api/goods/**")
+        antMatcher("/api/goods/**"),
+        antMatcher("/api/trade/**")
     );
     return requestMatchers.toArray(RequestMatcher[]::new);
   }

--- a/src/main/java/com/unity/goods/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/unity/goods/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import com.unity.goods.domain.email.exception.EmailException;
 import com.unity.goods.domain.goods.exception.GoodsException;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.oauth.exception.OAuthException;
+import com.unity.goods.domain.trade.exception.TradeException;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -17,6 +18,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(TradeException.class)
+  public ErrorResponse handleTradeException(TradeException e) {
+    log.error("Exception \"{}({})\" is occurred.", e.getErrorCode(), e.getErrorCode().getMessage());
+
+    return new ErrorResponse(e.getErrorCode(), e.getErrorCode().getStatus(),
+        e.getErrorCode().getMessage());
+  }
 
   @ExceptionHandler(GoodsException.class)
   public ErrorResponse handleGoodsException(GoodsException e) {


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 새로운 기능 추가

### 반영 브랜치
-  feat/goods-purchase-list -> feat/goods

### 변경 사항
- Domain 계층에 trade에 관련된 domain을 생성했습니다.
- Trade 엔티티는 Goods, Member 엔티티와 양방향 연관관계를 설정하였습니다.
- 회원은 본인이 구매한 목록을 최신 거래순으로 조회할 수 있습니다.
- Pageable 인터페이스를 사용하여 Trade 엔티티를 Page로 받아오도록 했습니다.
- Trade 엔티티와 매핑된 Goods, Member 엔티티를 참조하여 상품과, 판매자에 대한 정보를 가져오도록
  로직을 구현하였으며, Trade의 ManyToOne 연관관계 매핑에 Fetch.Lazy 옵션을 주었기 때문에 참조 엔티티 조회
  쿼리가 N+1 문제가  발생할 것을 고려하여 DB에서 Trade를 page로 가져올 때 fetch join으로 매핑값을 가져올 수 있도록 
   EntityGraph 옵션을  설정하였습니다.

### PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)