### PR TITLE
Feat: 상품 판매목록 조회 기능 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 /src/main/resources/application-private.yml
 /src/main/resources/schema.sql
 /src/main/resources/data.sql
+/docker-compose-private.yml

--- a/src/main/java/com/unity/goods/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/unity/goods/domain/goods/controller/GoodsController.java
@@ -1,6 +1,7 @@
 package com.unity.goods.domain.goods.controller;
 
 import com.unity.goods.domain.goods.dto.GoodsDetailDto;
+import com.unity.goods.domain.goods.dto.SellerSalesListDto.SellerSalesListResponse;
 import com.unity.goods.domain.goods.dto.UpdateGoodsInfoDto.UpdateGoodsInfoRequest;
 import com.unity.goods.domain.goods.dto.UpdateGoodsInfoDto.UpdateGoodsInfoResponse;
 import com.unity.goods.domain.goods.dto.UpdateGoodsStateDto.UpdateGoodsStateRequest;
@@ -66,7 +67,7 @@ public class GoodsController {
 
     return ResponseEntity.ok(updateGoodsInfoResponse);
   }
-  
+
   @PutMapping("/{goodsId}/state")
   public ResponseEntity<?> updateState(
       @AuthenticationPrincipal UserDetailsImpl member,
@@ -84,13 +85,25 @@ public class GoodsController {
     goodsService.deleteGoods(member, goodsId);
     return ResponseEntity.ok().build();
   }
-  
+
   @GetMapping("/search")
   public ResponseEntity<?> search(
       @RequestParam(name = "keyword") String keyword,
       @PageableDefault Pageable pageable) {
     Page<GoodsDocument> goodsDocumentPage = goodsSearchService.search(keyword, pageable);
     return ResponseEntity.ok(goodsDocumentPage);
+  }
+
+  @GetMapping("/sell-list/{sellerId}")
+  public ResponseEntity<?> salesGoodsList(
+      @PathVariable Long sellerId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+
+    Page<SellerSalesListResponse> sellerSalesList
+        = goodsService.getSellerSalesList(sellerId, page, size);
+
+    return ResponseEntity.ok(sellerSalesList);
   }
 
 }

--- a/src/main/java/com/unity/goods/domain/goods/dto/SellerSalesListDto.java
+++ b/src/main/java/com/unity/goods/domain/goods/dto/SellerSalesListDto.java
@@ -1,0 +1,21 @@
+package com.unity.goods.domain.goods.dto;
+
+import com.unity.goods.domain.goods.type.GoodsStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+public class SellerSalesListDto {
+
+  @Getter
+  @Builder
+  public static class SellerSalesListResponse {
+
+    private Long goodsId;
+    private String sellerName;
+    private String goodsName;
+    private String price;
+    private String goodsThumbnail;
+    private GoodsStatus goodsStatus;
+    private Long uploadedBefore;
+  }
+}

--- a/src/main/java/com/unity/goods/domain/goods/repository/GoodsRepository.java
+++ b/src/main/java/com/unity/goods/domain/goods/repository/GoodsRepository.java
@@ -1,11 +1,13 @@
 package com.unity.goods.domain.goods.repository;
 
 import com.unity.goods.domain.goods.entity.Goods;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GoodsRepository extends JpaRepository<Goods, Long> {
 
-
+  Page<Goods> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
@@ -31,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
@@ -9,6 +9,7 @@ import static com.unity.goods.global.exception.ErrorCode.NEED_LEAST_ONE_IMAGE;
 import static com.unity.goods.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.unity.goods.domain.goods.dto.GoodsDetailDto.GoodsDetailResponse;
+import com.unity.goods.domain.goods.dto.SellerSalesListDto.SellerSalesListResponse;
 import com.unity.goods.domain.goods.dto.UpdateGoodsInfoDto.UpdateGoodsInfoRequest;
 import com.unity.goods.domain.goods.dto.UpdateGoodsInfoDto.UpdateGoodsInfoResponse;
 import com.unity.goods.domain.goods.dto.UpdateGoodsStateDto.UpdateGoodsStateRequest;
@@ -25,12 +26,19 @@ import com.unity.goods.domain.member.repository.MemberRepository;
 import com.unity.goods.global.jwt.UserDetailsImpl;
 import com.unity.goods.infra.service.GoodsSearchService;
 import com.unity.goods.infra.service.S3Service;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -175,5 +183,36 @@ public class GoodsService {
     log.info("[GoodsService][deleteGoods] : \"GoodsId: {}, GoodsName: {}\" 상품 삭제"
         , goods.getId(), goods.getGoodsName());
     goodsRepository.deleteById(goodsId);
+  }
+
+  public Page<SellerSalesListResponse> getSellerSalesList(Long sellerId, int page, int size) {
+
+    Member seller = memberRepository.findById(sellerId)
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+    Page<Goods> salesPage = goodsRepository.findByMemberId(sellerId, pageable);
+
+    List<SellerSalesListResponse> salesList = salesPage.getContent().stream()
+        .map(goods -> {
+          String imageUrl =
+              goods.getImageList().isEmpty() ? null : goods.getImageList().get(0).getImageUrl();
+
+          return SellerSalesListResponse.builder()
+              .goodsId(goods.getId())
+              .sellerName(seller.getNickname())
+              .goodsName(goods.getGoodsName())
+              .price(String.valueOf(goods.getPrice()))
+              .goodsThumbnail(imageUrl)
+              .goodsStatus(goods.getGoodsStatus())
+              .uploadedBefore(getTradedBeforeSeconds(goods.getCreatedAt()))
+              .build();
+        }).collect(Collectors.toList());
+
+    return new PageImpl<>(salesList, pageable, salesPage.getTotalElements());
+  }
+
+  private static long getTradedBeforeSeconds(LocalDateTime tradedDateTime) {
+    return Duration.between(tradedDateTime, LocalDateTime.now()).getSeconds();
   }
 }

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.unity.goods.global.config;
 
-import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
@@ -86,7 +85,8 @@ public class SecurityConfig {
         antMatcher(POST, "/api/member/reissue"), // 토큰 재발급
         antMatcher(GET,"/api/member/badge"), // 배지 조회
         antMatcher(POST, "/api/email/**"), // 이메일 인증
-        antMatcher(GET, "/api/goods/search")
+        antMatcher(GET, "/api/goods/search"),
+        antMatcher(GET, "/api/goods/sell-list/**")
     );
     return requestMatchers.toArray(RequestMatcher[]::new);
   }


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 새로운 기능 추가


### 반영 브랜치
-  feat/goods-sales-list -> feat/goods

### 변경 사항
- 판매자의 id를 Request 하여 판매자의 판매 목록을 조회할 수 있습니다.
- 비회원/회원 모두 조회 가능합니다.
- 판매자의 판매목록을 생성일 기준 오름차순으로 response합니다.
- 상품id, 판매자 이름, 상품 이름, 상품가격, 상품 썸네일이미지, 상품 상태, 상품 등록일을
  응답값으로 페이징 처리해서 클라이언트에게 보냅니다.

### PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)