### PR TITLE
Feat/point : 포인트 충전, 포인트 잔액 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -26,6 +27,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+    implementation 'com.github.iamport:iamport-rest-client-java:0.1.6'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
+++ b/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
@@ -22,7 +22,7 @@ public class UpdateGoodsInfoDto {
     private String goodsName;
 
     @NotBlank(message = "상품 가격을 입력해주세요.")
-    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
+    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0또는 (-)로 시작하지 않는 숫자로 입력해야 합니다.")
     private String price;
 
     @NotBlank(message = "상품 설명을 작성해주세요.")

--- a/src/main/java/com/unity/goods/domain/goods/dto/UploadGoodsDto.java
+++ b/src/main/java/com/unity/goods/domain/goods/dto/UploadGoodsDto.java
@@ -24,7 +24,7 @@ public class UploadGoodsDto {
     private List<MultipartFile> goodsImageFiles;
 
     @NotBlank(message = "상품 가격을 입력해주세요.")
-    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
+    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0또는 (-)로 시작하지 않는 숫자로 입력해야 합니다.")
     private String price;
 
     @NotBlank(message = "상품명을 입력해주세요.")

--- a/src/main/java/com/unity/goods/domain/point/config/IamPortConfig.java
+++ b/src/main/java/com/unity/goods/domain/point/config/IamPortConfig.java
@@ -1,0 +1,22 @@
+package com.unity.goods.domain.point.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IamPortConfig {
+
+  @Value("${imp.api.key}")
+  private String apikey;
+
+  @Value("${imp.api.secretkey}")
+  private String secretkey;
+
+  @Bean
+  public IamportClient iamportClient() {
+    return new IamportClient(apikey, secretkey);
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/point/controller/PointController.java
+++ b/src/main/java/com/unity/goods/domain/point/controller/PointController.java
@@ -1,0 +1,32 @@
+package com.unity.goods.domain.point.controller;
+
+import com.unity.goods.domain.point.dto.PointChargeDto;
+import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
+import com.unity.goods.domain.point.service.PointService;
+import com.unity.goods.global.jwt.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/point")
+public class PointController {
+
+  private final PointService pointService;
+
+  @PostMapping("/charge")
+  public ResponseEntity<?> chargePoint(
+      @AuthenticationPrincipal UserDetailsImpl member,
+      @Valid @RequestBody PointChargeDto.PointChargeRequest pointChargeRequest
+  ) {
+    PointChargeResponse pointChargeResponse = pointService.chargePoint(member, pointChargeRequest);
+    return ResponseEntity.ok(pointChargeResponse);
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/point/controller/PointController.java
+++ b/src/main/java/com/unity/goods/domain/point/controller/PointController.java
@@ -1,5 +1,6 @@
 package com.unity.goods.domain.point.controller;
 
+import com.unity.goods.domain.point.dto.PointBalanceDto.PointBalanceResponse;
 import com.unity.goods.domain.point.dto.PointChargeDto;
 import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
 import com.unity.goods.domain.point.service.PointService;
@@ -8,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +29,12 @@ public class PointController {
   ) {
     PointChargeResponse pointChargeResponse = pointService.chargePoint(member, pointChargeRequest);
     return ResponseEntity.ok(pointChargeResponse);
+  }
+
+  @GetMapping("/balance")
+  public ResponseEntity<?> getBalance(@AuthenticationPrincipal UserDetailsImpl member) {
+    PointBalanceResponse pointBalanceResponse = pointService.getBalance(member);
+    return ResponseEntity.ok(pointBalanceResponse);
   }
 
 }

--- a/src/main/java/com/unity/goods/domain/point/dto/PointBalanceDto.java
+++ b/src/main/java/com/unity/goods/domain/point/dto/PointBalanceDto.java
@@ -1,0 +1,14 @@
+package com.unity.goods.domain.point.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class PointBalanceDto {
+
+  @Getter
+  @Builder
+  public static class PointBalanceResponse {
+    private String price;
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/point/dto/PointChargeDto.java
+++ b/src/main/java/com/unity/goods/domain/point/dto/PointChargeDto.java
@@ -1,0 +1,32 @@
+package com.unity.goods.domain.point.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class PointChargeDto {
+
+  @Getter
+  @Setter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class PointChargeRequest {
+
+    @NotBlank(message = "상품 가격을 입력해주세요.")
+    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
+    private String price;
+
+  }
+
+  @Getter
+  @Builder
+  public static class PointChargeResponse {
+    private String paymentStatus;
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/point/dto/PointChargeDto.java
+++ b/src/main/java/com/unity/goods/domain/point/dto/PointChargeDto.java
@@ -18,7 +18,7 @@ public class PointChargeDto {
   public static class PointChargeRequest {
 
     @NotBlank(message = "상품 가격을 입력해주세요.")
-    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
+    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0또는 (-)로 시작하지 않는 숫자로 입력해야 합니다.")
     private String price;
 
   }

--- a/src/main/java/com/unity/goods/domain/point/entity/Point.java
+++ b/src/main/java/com/unity/goods/domain/point/entity/Point.java
@@ -1,0 +1,37 @@
+package com.unity.goods.domain.point.entity;
+
+import com.unity.goods.domain.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Point {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "point_id")
+  private Long id;
+
+  @Column(nullable = false)
+  private Long balance;
+
+  @OneToOne
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+}

--- a/src/main/java/com/unity/goods/domain/point/exception/PointException.java
+++ b/src/main/java/com/unity/goods/domain/point/exception/PointException.java
@@ -1,0 +1,9 @@
+package com.unity.goods.domain.point.exception;
+
+import com.unity.goods.global.exception.CustomException;
+import com.unity.goods.global.exception.ErrorCode;
+
+public class PointException extends CustomException {
+
+  public PointException(ErrorCode errorCode) {super(errorCode);}
+}

--- a/src/main/java/com/unity/goods/domain/point/repository/PointRepository.java
+++ b/src/main/java/com/unity/goods/domain/point/repository/PointRepository.java
@@ -1,0 +1,13 @@
+package com.unity.goods.domain.point.repository;
+
+import com.unity.goods.domain.member.entity.Member;
+import com.unity.goods.domain.point.entity.Point;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PointRepository extends JpaRepository<Point, Long> {
+
+  Optional<Point> findByMember(Member member);
+}

--- a/src/main/java/com/unity/goods/domain/point/service/PointService.java
+++ b/src/main/java/com/unity/goods/domain/point/service/PointService.java
@@ -5,6 +5,7 @@ import static com.unity.goods.global.exception.ErrorCode.USER_NOT_FOUND;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.MemberRepository;
+import com.unity.goods.domain.point.dto.PointBalanceDto.PointBalanceResponse;
 import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeRequest;
 import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
 import com.unity.goods.domain.point.entity.Point;
@@ -44,6 +45,20 @@ public class PointService {
 
     pointRepository.save(chargePoint);
     return PointChargeResponse.builder().paymentStatus(String.valueOf(PaymentStatus.SUCCESS))
+        .build();
+  }
+
+  public PointBalanceResponse getBalance(UserDetailsImpl member) {
+
+    Member findMember = memberRepository.findByEmail(member.getUsername())
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    Optional<Point> optionalPoint = pointRepository.findByMember(findMember);
+    if (optionalPoint.isEmpty()) {
+      return PointBalanceResponse.builder().price("0").build();
+    }
+
+    return PointBalanceResponse.builder().price(optionalPoint.get().getBalance().toString())
         .build();
   }
 }

--- a/src/main/java/com/unity/goods/domain/point/service/PointService.java
+++ b/src/main/java/com/unity/goods/domain/point/service/PointService.java
@@ -1,0 +1,49 @@
+package com.unity.goods.domain.point.service;
+
+import static com.unity.goods.global.exception.ErrorCode.USER_NOT_FOUND;
+
+import com.unity.goods.domain.member.entity.Member;
+import com.unity.goods.domain.member.exception.MemberException;
+import com.unity.goods.domain.member.repository.MemberRepository;
+import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeRequest;
+import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
+import com.unity.goods.domain.point.entity.Point;
+import com.unity.goods.domain.point.repository.PointRepository;
+import com.unity.goods.domain.point.type.PaymentStatus;
+import com.unity.goods.global.jwt.UserDetailsImpl;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+  private final MemberRepository memberRepository;
+  private final PointRepository pointRepository;
+
+  public PointChargeResponse chargePoint(UserDetailsImpl member,
+      PointChargeRequest pointChargeRequest) {
+
+    Member findMember = memberRepository.findByEmail(member.getUsername())
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    // 이전에 포인트 충전을 한 적이 있는 사람인지 확인
+    Optional<Point> optionalPoint = pointRepository.findByMember(findMember);
+    Point chargePoint;
+    if (optionalPoint.isPresent()) {
+      chargePoint = optionalPoint.get();
+      chargePoint.setBalance(
+          chargePoint.getBalance() + Long.parseLong(pointChargeRequest.getPrice()));
+    } else {
+      chargePoint = Point.builder()
+          .member(findMember)
+          .balance(Long.parseLong(pointChargeRequest.getPrice()))
+          .build();
+    }
+
+    pointRepository.save(chargePoint);
+    return PointChargeResponse.builder().paymentStatus(String.valueOf(PaymentStatus.SUCCESS))
+        .build();
+  }
+}

--- a/src/main/java/com/unity/goods/domain/point/type/PaymentStatus.java
+++ b/src/main/java/com/unity/goods/domain/point/type/PaymentStatus.java
@@ -1,0 +1,6 @@
+package com.unity.goods.domain.point.type;
+
+public enum PaymentStatus {
+  SUCCESS,
+  FAIL
+}

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -100,7 +100,8 @@ public class SecurityConfig {
         antMatcher(PUT, "/api/member/password"), // 비밀번호 변경
         antMatcher(PUT, "/api/member/trade-password"), // 거래 비밀번호 변경
         antMatcher(POST, "/api/goods/new"),
-        antMatcher("/api/goods/**")
+        antMatcher("/api/goods/**"),
+        antMatcher("/api/point/**")
     );
     return requestMatchers.toArray(RequestMatcher[]::new);
   }

--- a/src/main/java/com/unity/goods/global/exception/AuthenticationEntryPointHandler.java
+++ b/src/main/java/com/unity/goods/global/exception/AuthenticationEntryPointHandler.java
@@ -25,7 +25,7 @@ public class AuthenticationEntryPointHandler implements AuthenticationEntryPoint
       AuthenticationException authException)
       throws IOException {
 
-    log.debug("[JwtAuthenticationEntryPoint] : 인증 실패");
+    log.error("[JwtAuthenticationEntryPoint] : 인증 실패");
     setResponse(response);
   }
 
@@ -34,8 +34,11 @@ public class AuthenticationEntryPointHandler implements AuthenticationEntryPoint
     // HTTP 응답 response 생성
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType("application/json;charset=UTF-8");
-    JwtFilterAuthenticationException exception = new JwtFilterAuthenticationException(UNAUTHORIZED);
-    String jsonResponse = objectMapper.writeValueAsString(exception);
+    String jsonResponse = objectMapper.writeValueAsString(ErrorResponse.builder()
+        .message(UNAUTHORIZED.getMessage())
+        .status(401)
+        .errorCode(UNAUTHORIZED)
+        .build());
 
     // JSON 응답 전송
     response.getWriter().write(jsonResponse);

--- a/src/main/java/com/unity/goods/global/exception/ErrorResponse.java
+++ b/src/main/java/com/unity/goods/global/exception/ErrorResponse.java
@@ -1,12 +1,14 @@
 package com.unity.goods.global.exception;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ErrorResponse {

--- a/src/main/java/com/unity/goods/global/exception/JwtFilterAuthenticationException.java
+++ b/src/main/java/com/unity/goods/global/exception/JwtFilterAuthenticationException.java
@@ -1,8 +1,0 @@
-package com.unity.goods.global.exception;
-
-public class JwtFilterAuthenticationException extends CustomException{
-
-  public JwtFilterAuthenticationException(ErrorCode errorCode) {
-    super(errorCode);
-  }
-}

--- a/src/test/java/com/unity/goods/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/unity/goods/domain/point/service/PointServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.repository.MemberRepository;
+import com.unity.goods.domain.point.dto.PointBalanceDto.PointBalanceResponse;
 import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeRequest;
 import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
 import com.unity.goods.domain.point.entity.Point;
@@ -90,6 +91,53 @@ class PointServiceTest {
     verify(pointRepository).save(pointCaptor.capture());
     Point savedPoint = pointCaptor.getValue();
     assertEquals(5000L, savedPoint.getBalance());
+  }
+
+  @Test
+  @DisplayName("충전 이력 O 유저 포인트 잔액 조회")
+  void getBalanceTest() {
+    // given
+    Member member = Member.builder()
+        .id(1L)
+        .email("test@email.com")
+        .build();
+
+    Point point = Point.builder()
+        .member(member)
+        .balance(1000L)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(member);
+
+    given(memberRepository.findByEmail(any(String.class))).willReturn(Optional.of(member));
+    given(pointRepository.findByMember(any(Member.class))).willReturn(Optional.of(point));
+
+    // when
+    PointBalanceResponse pointBalanceResponse = pointService.getBalance(userDetails);
+
+    // then
+    assertEquals(1000L, Long.parseLong(pointBalanceResponse.getPrice()));
+  }
+
+  @Test
+  @DisplayName("포인트 충전 이력 X 유저 포인트 잔액 조회")
+  void getFirstBalanceTest() {
+    // given
+    Member member = Member.builder()
+        .id(1L)
+        .email("test@email.com")
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(member);
+
+    given(memberRepository.findByEmail(any(String.class))).willReturn(Optional.of(member));
+    given(pointRepository.findByMember(any(Member.class))).willReturn(Optional.empty());
+
+    // when
+    PointBalanceResponse pointBalanceResponse = pointService.getBalance(userDetails);
+
+    // then
+    assertEquals(0L, Long.parseLong(pointBalanceResponse.getPrice()));
   }
 
 }

--- a/src/test/java/com/unity/goods/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/unity/goods/domain/point/service/PointServiceTest.java
@@ -1,0 +1,95 @@
+package com.unity.goods.domain.point.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+
+import com.unity.goods.domain.member.entity.Member;
+import com.unity.goods.domain.member.repository.MemberRepository;
+import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeRequest;
+import com.unity.goods.domain.point.dto.PointChargeDto.PointChargeResponse;
+import com.unity.goods.domain.point.entity.Point;
+import com.unity.goods.domain.point.repository.PointRepository;
+import com.unity.goods.domain.point.type.PaymentStatus;
+import com.unity.goods.global.jwt.UserDetailsImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PointServiceTest {
+
+  @InjectMocks
+  private PointService pointService;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private PointRepository pointRepository;
+
+  @Test
+  @DisplayName("기존 충전했던 사람 포인트 충전")
+  void chargePointTest() {
+    // given
+    Member member = Member.builder()
+        .id(1L)
+        .email("test@email.com")
+        .build();
+
+    Point point = Point.builder()
+        .member(member)
+        .balance(1000L)
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(member);
+
+    given(memberRepository.findByEmail(any(String.class))).willReturn(Optional.of(member));
+    given(pointRepository.findByMember(any(Member.class))).willReturn(Optional.of(point));
+
+    // when
+    PointChargeResponse pointChargeResponse = pointService.chargePoint(userDetails,
+        PointChargeRequest.builder().price("5000").build());
+
+    // then
+    assertEquals(PaymentStatus.SUCCESS.toString(), pointChargeResponse.getPaymentStatus());
+    ArgumentCaptor<Point> pointCaptor = ArgumentCaptor.forClass(Point.class);
+    verify(pointRepository).save(pointCaptor.capture());
+    Point savedPoint = pointCaptor.getValue();
+    assertEquals(6000L, savedPoint.getBalance());
+  }
+
+  @Test
+  @DisplayName("처음 충전하는 사람 포인트 충전")
+  void newChargePointTest() {
+    // given
+    Member member = Member.builder()
+        .id(1L)
+        .email("test@email.com")
+        .build();
+
+    UserDetailsImpl userDetails = new UserDetailsImpl(member);
+
+    given(memberRepository.findByEmail(any(String.class))).willReturn(Optional.of(member));
+    given(pointRepository.findByMember(any(Member.class))).willReturn(Optional.empty());
+
+    // when
+    PointChargeResponse pointChargeResponse = pointService.chargePoint(userDetails,
+        PointChargeRequest.builder().price("5000").build());
+
+    // then
+    assertEquals(PaymentStatus.SUCCESS.toString(), pointChargeResponse.getPaymentStatus());
+    ArgumentCaptor<Point> pointCaptor = ArgumentCaptor.forClass(Point.class);
+    verify(pointRepository).save(pointCaptor.capture());
+    Point savedPoint = pointCaptor.getValue();
+    assertEquals(5000L, savedPoint.getBalance());
+  }
+
+}


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
ex) feat/point-> feat/goods

### 변경 사항
* 포인트 충전 기능 구현
    * 이전 포인트 충전 이력 여부에 따라 기존 포인트에 추가 / 충전 금액만 추가 구분   
* 포인트 잔액 조회 기능 구현
    * 이전 포인트 충전 이력 여부에 따라 이력 X으면 0원으로 조회되게 설정, (point save 기능은 충전 메서드에서만 진행)
* regexp = "^[1-9][0-9]*$"가 이미 (-)로 시작하지 않게 막고 있어. 메시지만 수정

(지금 구현된 상태는 기존 내용 X, 질문한 내용으로 구현됨)
* 잔액 조회 api 가 "api/point/my" 던데 이름에 맞게 "api/point/balance" 어떤가요? 
* 잔액 조회 api POST 매핑이던데 조회니까 GET 어떤가요?
* erd에 point - member 다대일 관계 던데 충전 유형(ex.카드사별)이 없어서 1대1 매핑 같은데 어떤가요?
<위의 사항 정해지면 수정 후에 merge 하겠습니다>

### PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)