### PR TITLE
Refactor: 상품 기능 리팩토링

### DIFF
--- a/src/main/java/com/unity/goods/domain/goods/controller/GoodsController.java
+++ b/src/main/java/com/unity/goods/domain/goods/controller/GoodsController.java
@@ -54,13 +54,13 @@ public class GoodsController {
     return ResponseEntity.ok(uploadGoodsResponse);
   }
 
-  @GetMapping("/{id}")
+  @GetMapping("/{goodsId}")
   public ResponseEntity<?> getDetailGoods(
       @AuthenticationPrincipal UserDetailsImpl member,
-      @PathVariable Long id
+      @PathVariable Long goodsId
   ) {
     GoodsDetailDto.GoodsDetailResponse goodsDetailResponse =
-        goodsService.getDetailGoods(member, id);
+        goodsService.getDetailGoods(member, goodsId);
     return ResponseEntity.ok(goodsDetailResponse);
   }
 

--- a/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
+++ b/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
@@ -29,8 +29,8 @@ public class UpdateGoodsInfoDto {
     private String description;
 
 
-    private List<String> goodsImageUrl;
-    private List<MultipartFile> goodsImageFile;
+    private List<String> imagesToDelete;
+    private List<MultipartFile> imagesToUpdate;
 
     @NotNull
     private Double lat;

--- a/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
+++ b/src/main/java/com/unity/goods/domain/goods/dto/UpdateGoodsInfoDto.java
@@ -29,7 +29,8 @@ public class UpdateGoodsInfoDto {
     private String description;
 
 
-    private List<MultipartFile> goodsImages;
+    private List<String> goodsImageUrl;
+    private List<MultipartFile> goodsImageFile;
 
     @NotNull
     private Double lat;

--- a/src/main/java/com/unity/goods/domain/goods/repository/ImageRepository.java
+++ b/src/main/java/com/unity/goods/domain/goods/repository/ImageRepository.java
@@ -2,6 +2,7 @@ package com.unity.goods.domain.goods.repository;
 
 import com.unity.goods.domain.goods.entity.Image;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,5 @@ import org.springframework.stereotype.Repository;
 public interface ImageRepository extends JpaRepository<Image, Long> {
   List<Image> findByGoodsId(Long goodsId);
 
+  void deleteImageByImageUrl(String url);
 }

--- a/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
@@ -2,6 +2,7 @@ package com.unity.goods.domain.goods.service;
 
 import static com.unity.goods.domain.goods.type.GoodsStatus.SOLDOUT;
 import static com.unity.goods.global.exception.ErrorCode.ALREADY_SOLD_OUT_GOODS;
+import static com.unity.goods.global.exception.ErrorCode.CANNOT_DELETE_SOLD_ITEM;
 import static com.unity.goods.global.exception.ErrorCode.GOODS_NOT_FOUND;
 import static com.unity.goods.global.exception.ErrorCode.MAX_IMAGE_LIMIT_EXCEEDED;
 import static com.unity.goods.global.exception.ErrorCode.MISMATCHED_SELLER;
@@ -19,6 +20,7 @@ import com.unity.goods.domain.goods.entity.Image;
 import com.unity.goods.domain.goods.exception.GoodsException;
 import com.unity.goods.domain.goods.repository.GoodsRepository;
 import com.unity.goods.domain.goods.repository.ImageRepository;
+import com.unity.goods.domain.goods.type.GoodsStatus;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.MemberRepository;
@@ -164,6 +166,11 @@ public class GoodsService {
 
     if (!goods.getMember().getEmail().equals(member.getUsername())) {
       throw new GoodsException(MISMATCHED_SELLER);
+    }
+
+    // 판매완료 상품은 삭제 불가능
+    if (goods.getGoodsStatus() == SOLDOUT) {
+      throw new GoodsException(CANNOT_DELETE_SOLD_ITEM);
     }
 
     for (Image goodsImageUrl : goods.getImageList()) {

--- a/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
@@ -22,7 +22,6 @@ import com.unity.goods.domain.goods.exception.GoodsException;
 import com.unity.goods.domain.goods.repository.GoodsRepository;
 import com.unity.goods.domain.goods.repository.ImageRepository;
 import com.unity.goods.domain.goods.repository.WishRepository;
-import com.unity.goods.domain.member.entity.Badge;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.BadgeRepository;
@@ -47,7 +46,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -148,24 +146,24 @@ public class GoodsService {
       throw new GoodsException(ALREADY_SOLD_OUT_GOODS);
     }
 
-    int deleteImageCnt = (updateGoodsInfoRequest.getGoodsImageUrl()) == null ? 0
-        : updateGoodsInfoRequest.getGoodsImageUrl().size();
+    int deleteImageCnt = (updateGoodsInfoRequest.getImagesToDelete()) == null ? 0
+        : updateGoodsInfoRequest.getImagesToDelete().size();
 
-    int addImageCnt = (updateGoodsInfoRequest.getGoodsImageFile()) == null ? 0
-        : updateGoodsInfoRequest.getGoodsImageFile().size();
+    int addImageCnt = (updateGoodsInfoRequest.getImagesToUpdate()) == null ? 0
+        : updateGoodsInfoRequest.getImagesToUpdate().size();
 
     if (goods.getImageList().size() - deleteImageCnt + addImageCnt > MAX_IMAGE_NUM) {
       log.error("[GoodsService][updateGoodsInfo] : \"{}\" 상품 이미지 등록 개수 초과", goods.getGoodsName());
       throw new GoodsException(MAX_IMAGE_LIMIT_EXCEEDED);
     }
 
-    Optional.ofNullable(updateGoodsInfoRequest.getGoodsImageUrl())
+    Optional.ofNullable(updateGoodsInfoRequest.getImagesToDelete())
         .ifPresent(urls -> urls.forEach(goodsUrl -> {
           imageRepository.deleteImageByImageUrl(goodsUrl);
           s3Service.deleteFile(goodsUrl);
         }));
 
-    Optional.ofNullable(updateGoodsInfoRequest.getGoodsImageFile())
+    Optional.ofNullable(updateGoodsInfoRequest.getImagesToUpdate())
         .ifPresent(files ->
             files.stream()
                 .map(multipart -> s3Service.uploadFile(multipart, member.getUsername() + "/" + goods.getGoodsName()))

--- a/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
+++ b/src/main/java/com/unity/goods/domain/goods/service/GoodsService.java
@@ -96,12 +96,12 @@ public class GoodsService {
     return UploadGoodsResponse.fromGoods(goods);
   }
 
-  public GoodsDetailResponse getDetailGoods(UserDetailsImpl member, Long id) {
+  public GoodsDetailResponse getDetailGoods(UserDetailsImpl member, Long goodsId) {
 
     Member findMember = memberRepository.findByEmail(member.getUsername())
         .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
-    Goods goods = goodsRepository.findById(id)
+    Goods goods = goodsRepository.findById(goodsId)
         .orElseThrow(() -> new GoodsException(GOODS_NOT_FOUND));
 
     GoodsDetailResponse goodsDetailResponse = GoodsDetailResponse.fromGoodsAndMember(goods,

--- a/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
@@ -10,6 +10,7 @@ public class MemberProfileDto {
   @Builder
   public static class MemberProfileResponse {
 
+    private Long memberId;
     private String nickName;
     private String phoneNumber;
     private String profileImage;
@@ -18,6 +19,7 @@ public class MemberProfileDto {
     public static MemberProfileResponse fromMember(Member member) {
 
       return MemberProfileResponse.builder()
+          .memberId(member.getId())
           .nickName(member.getNickname())
           .phoneNumber(member.getPhoneNumber())
           .profileImage(member.getProfileImage())

--- a/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
@@ -1,6 +1,9 @@
 package com.unity.goods.domain.member.dto;
 
+import static com.unity.goods.domain.member.entity.Badge.badgeToString;
+
 import com.unity.goods.domain.member.entity.Member;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,6 +18,7 @@ public class MemberProfileDto {
     private String phoneNumber;
     private String profileImage;
     private double star;
+    private List<String> badgeList;
 
     public static MemberProfileResponse fromMember(Member member) {
 
@@ -24,9 +28,8 @@ public class MemberProfileDto {
           .phoneNumber(member.getPhoneNumber())
           .profileImage(member.getProfileImage())
           .star(member.getStar())
+          .badgeList(badgeToString(member.getBadgeList()))
           .build();
     }
-
   }
-
 }

--- a/src/main/java/com/unity/goods/domain/member/dto/UpdateProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/UpdateProfileDto.java
@@ -15,9 +15,6 @@ public class UpdateProfileDto {
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
     private String nickName;
 
-    @Pattern(regexp = "^[0-9]{6}$", message = "거래 비밀번호는 6자리 숫자로 작성해주세요.")
-    private String tradePassword;
-
     private String phoneNumber;
 
     private MultipartFile profileImage;

--- a/src/main/java/com/unity/goods/domain/member/dto/UpdateProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/UpdateProfileDto.java
@@ -17,7 +17,8 @@ public class UpdateProfileDto {
 
     private String phoneNumber;
 
-    private MultipartFile profileImage;
+    private String profileImageUrl;
+    private MultipartFile profileImageFile;
 
   }
 

--- a/src/main/java/com/unity/goods/domain/member/entity/Badge.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Badge.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,4 +33,10 @@ public class Badge {
 
   @Enumerated(EnumType.STRING)
   private BadgeType badge;
+
+  public static List<String> badgeToString(List<Badge> badges) {
+    return badges.stream()
+        .map(badge -> badge.getBadge().getDescription())
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/java/com/unity/goods/domain/member/entity/Member.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Member.java
@@ -72,7 +72,11 @@ public class Member extends BaseEntity {
   private List<Goods> goodsList = new ArrayList<>();
 
   @OneToMany(mappedBy = "member")
-  private List<Trade> tradeList  = new ArrayList<>();
+  private List<Trade> tradeList = new ArrayList<>();
+
+  @OneToMany(mappedBy = "member")
+  @Builder.Default
+  private List<Badge> badgeList = new ArrayList<>();
 
   public static Member fromSignUpRequest(SignUpRequest signUpRequest, String imageUrl) {
 

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -317,23 +317,15 @@ public class MemberService {
       findMember.setPhoneNumber(updateProfileRequest.getPhoneNumber());
     }
 
-    // 기존에 프로필 이미지가 없고, 새로운 프로필 이미지 요청 왔을 떄
-    if (updateProfileRequest.getProfileImageUrl() == null
-        && updateProfileRequest.getProfileImageFile() != null) {
-
-      findMember.setProfileImage(
-          s3Service.uploadFile(
-              updateProfileRequest.getProfileImageFile(), member.getUsername()));
-    }
-
-    // 기존에 프로필 이미지가 있고, 새로운 프로필 이미지 요청 왔을 떄
-    if (updateProfileRequest.getProfileImageUrl() != null
-        && updateProfileRequest.getProfileImageFile() != null) {
-
-      s3Service.deleteFile(findMember.getProfileImage());
-      findMember.setProfileImage(
-          s3Service.uploadFile(
-              updateProfileRequest.getProfileImageFile(), member.getUsername()));
+    if (updateProfileRequest.getProfileImageFile() != null) {
+      if (updateProfileRequest.getProfileImageUrl() != null) {
+        s3Service.deleteFile(findMember.getProfileImage());
+        log.info("[updateMemberProfile] : {} 기존 프로필 이미지 삭제 완료", member.getUsername());
+      }
+      String uploadedUrl = s3Service.uploadFile(updateProfileRequest.getProfileImageFile(),
+          member.getUsername() + "/" + "profileImage");
+      log.info("[updateMemberProfile] : {} 프로필 이미지 업로드 완료", member.getUsername());
+      findMember.setProfileImage(uploadedUrl);
     }
 
     return UpdateProfileResponse.fromMember(findMember);

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -313,10 +313,6 @@ public class MemberService {
       findMember.setNickname(updateProfileRequest.getNickName());
     }
 
-    if (updateProfileRequest.getTradePassword() != null) {
-      findMember.setTradePassword(updateProfileRequest.getTradePassword());
-    }
-
     if (updateProfileRequest.getPhoneNumber() != null) {
       findMember.setPhoneNumber(updateProfileRequest.getPhoneNumber());
     }

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -317,11 +317,11 @@ public class MemberService {
       findMember.setPhoneNumber(updateProfileRequest.getPhoneNumber());
     }
 
+    // 프로필 이미지를 교체하는 경우 기존 프로필 이미지 삭제 후 저장
     if (updateProfileRequest.getProfileImageFile() != null) {
-      if (updateProfileRequest.getProfileImageUrl() != null) {
-        s3Service.deleteFile(findMember.getProfileImage());
-        log.info("[updateMemberProfile] : {} 기존 프로필 이미지 삭제 완료", member.getUsername());
-      }
+      s3Service.deleteFile(findMember.getProfileImage());
+      log.info("[updateMemberProfile] : {} 기존 프로필 이미지 삭제 완료", member.getUsername());
+
       String uploadedUrl = s3Service.uploadFile(updateProfileRequest.getProfileImageFile(),
           member.getUsername() + "/" + "profileImage");
       log.info("[updateMemberProfile] : {} 프로필 이미지 업로드 완료", member.getUsername());

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -317,14 +317,23 @@ public class MemberService {
       findMember.setPhoneNumber(updateProfileRequest.getPhoneNumber());
     }
 
-    if (updateProfileRequest.getProfileImage() != null) {
-      // 기존에 프로필 이미지가 있다면 S3에서 파일 삭제
-      if (findMember.getProfileImage() != null) {
-        s3Service.deleteFile(findMember.getProfileImage());
-      }
+    // 기존에 프로필 이미지가 없고, 새로운 프로필 이미지 요청 왔을 떄
+    if (updateProfileRequest.getProfileImageUrl() == null
+        && updateProfileRequest.getProfileImageFile() != null) {
+
       findMember.setProfileImage(
           s3Service.uploadFile(
-              updateProfileRequest.getProfileImage(), member.getUsername()));
+              updateProfileRequest.getProfileImageFile(), member.getUsername()));
+    }
+
+    // 기존에 프로필 이미지가 있고, 새로운 프로필 이미지 요청 왔을 떄
+    if (updateProfileRequest.getProfileImageUrl() != null
+        && updateProfileRequest.getProfileImageFile() != null) {
+
+      s3Service.deleteFile(findMember.getProfileImage());
+      findMember.setProfileImage(
+          s3Service.uploadFile(
+              updateProfileRequest.getProfileImageFile(), member.getUsername()));
     }
 
     return UpdateProfileResponse.fromMember(findMember);

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.unity.goods.global.config;
 
-import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
@@ -84,8 +83,9 @@ public class SecurityConfig {
         antMatcher(POST, "/api/member/signup"), // 회원가입
         antMatcher(POST, "/api/member/login"),  // 로그인
         antMatcher(POST, "/api/member/reissue"), // 토큰 재발급
-        antMatcher(GET,"/api/member/badge"), // 배지 조회
+        antMatcher(GET, "/api/member/badge"), // 배지 조회
         antMatcher(POST, "/api/email/**"), // 이메일 인증
+        antMatcher(POST, "/api/member/find"), // 비밀번호 찾기
         antMatcher(POST, "/api/goods/search"), // 검색
         antMatcher(GET, "/api/goods")
     );
@@ -99,11 +99,13 @@ public class SecurityConfig {
         antMatcher(PUT, "/api/member/resign"), // 회원탈퇴
         antMatcher(PUT, "/api/member/password"), // 비밀번호 변경
         antMatcher(PUT, "/api/member/trade-password"), // 거래 비밀번호 변경
+        antMatcher(GET, "/api/member/profile"), // 회원정보 조회
+        antMatcher(PUT, "/api/member/profile"), // 회원정보 수정
         antMatcher(POST, "/api/goods/new"),
         antMatcher("/api/goods/**"),
         antMatcher("/api/trade/**")
     );
     return requestMatchers.toArray(RequestMatcher[]::new);
   }
-  
+
 }

--- a/src/main/java/com/unity/goods/global/exception/ErrorCode.java
+++ b/src/main/java/com/unity/goods/global/exception/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
   ALREADY_SOLD_OUT_GOODS(400, "이미 판매가 완료된 상품입니다."),
   MAX_IMAGE_LIMIT_EXCEEDED(404, "등록할 수 있는 이미지의 최대 개수를 초과하였습니다."),
   NEED_LEAST_ONE_IMAGE(400, "상품 등록 시 최소 1개의 이미지를 올려야 합니다."),
+  CANNOT_DELETE_SOLD_ITEM(400, "판매완료된 상품은 삭제할 수 없습니다."),
 
   // WishList Error
   GOODS_ALREADY_WISHLIST(400,"이미 찜한 상품입니다."),


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)

- [x] 코드 리팩토링

### 반영 브랜치
-  feat/goods-refator-chan-> feat/goods

### 변경 사항

[**UpdateGoodsInfoDto**] 
 - 상품 정보를 수정할 때 request로 기존의 url list와 추가 될 Multipart list 두 개를 받아오도록 수정했습니다.
 
[**updateGoodsInfo**] 
 - Request로 전달된 goodsImageUrl list와 현재 DB에 저장된 이미지를 비교하여 삭제된 url이 존재한다면
   imageRepository와 S3에서 삭제하도록 하였습니다.

 [**deleteGoods**] 
 - 판매된 상품은 별점에 영향을 주기 때문에 판매완료된 상품은 임의로 삭제하지 못하는 로직을 추가했습니다.
 
 [**MemberProfileDto**] 
 - 로그인 한 회원의 id를 클라이언트에 넘겨주도록 reponse에 추가했습니다.
 
[**UpdateProfileDto**] 
- 회원 정보를 수정할 때 request로 기존의 url과 추가 될 Multipart 두 개를 받아오도록 수정했습니다.
- 거래비밀번호를 업데이트 하는 부분을 삭제했습니다.
### PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)