### PR TITLE
Feat: 판매자 프로필 조회 기능 구현

### DIFF
--- a/src/main/java/com/unity/goods/domain/member/controller/MemberController.java
+++ b/src/main/java/com/unity/goods/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import static com.unity.goods.domain.member.dto.FindPasswordDto.FindPasswordRequ
 import com.unity.goods.domain.member.dto.LoginDto;
 import com.unity.goods.domain.member.dto.MemberProfileDto.MemberProfileResponse;
 import com.unity.goods.domain.member.dto.ResignDto;
+import com.unity.goods.domain.member.dto.SellerProfileDto.SellerProfileResponse;
 import com.unity.goods.domain.member.dto.SignUpDto;
 import com.unity.goods.domain.member.dto.UpdateProfileDto.UpdateProfileRequest;
 import com.unity.goods.domain.member.dto.UpdateProfileDto.UpdateProfileResponse;
@@ -23,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -86,6 +88,12 @@ public class MemberController {
   public ResponseEntity<?> getProfile(@AuthenticationPrincipal UserDetailsImpl member) {
     MemberProfileResponse memberProfile = memberService.getMemberProfile(member);
     return ResponseEntity.ok(memberProfile);
+  }
+
+  @GetMapping("/{sellerId}/profile")
+  public ResponseEntity<?> getProfile(@PathVariable Long sellerId) {
+    SellerProfileResponse sellerProfile = memberService.getSellerProfile(sellerId);
+    return ResponseEntity.ok(sellerProfile);
   }
 
   @PutMapping("/profile")

--- a/src/main/java/com/unity/goods/domain/member/dto/SellerProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/SellerProfileDto.java
@@ -6,24 +6,21 @@ import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
-public class MemberProfileDto {
+public class SellerProfileDto {
 
   @Getter
   @Builder
-  public static class MemberProfileResponse {
+  public static class SellerProfileResponse {
 
     private String nickName;
-    private String phoneNumber;
     private String profileImage;
     private double star;
     private List<Badge> badgeList;
 
+    public static SellerProfileResponse fromMember(Member member) {
 
-    public static MemberProfileResponse fromMember(Member member) {
-
-      return MemberProfileResponse.builder()
+      return SellerProfileResponse.builder()
           .nickName(member.getNickname())
-          .phoneNumber(member.getPhoneNumber())
           .profileImage(member.getProfileImage())
           .star(member.getStar())
           .badgeList(member.getBadgeList())

--- a/src/main/java/com/unity/goods/domain/member/dto/SellerProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/SellerProfileDto.java
@@ -1,6 +1,7 @@
 package com.unity.goods.domain.member.dto;
 
-import com.unity.goods.domain.member.entity.Badge;
+import static com.unity.goods.domain.member.entity.Badge.badgeToString;
+
 import com.unity.goods.domain.member.entity.Member;
 import java.util.List;
 import lombok.Builder;
@@ -15,7 +16,7 @@ public class SellerProfileDto {
     private String nickName;
     private String profileImage;
     private double star;
-    private List<Badge> badgeList;
+    private List<String> badgeList;
 
     public static SellerProfileResponse fromMember(Member member) {
 
@@ -23,7 +24,7 @@ public class SellerProfileDto {
           .nickName(member.getNickname())
           .profileImage(member.getProfileImage())
           .star(member.getStar())
-          .badgeList(member.getBadgeList())
+          .badgeList(badgeToString(member.getBadgeList()))
           .build();
     }
 

--- a/src/main/java/com/unity/goods/domain/member/entity/Badge.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Badge.java
@@ -9,6 +9,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,4 +33,11 @@ public class Badge {
 
   @Enumerated(EnumType.STRING)
   private BadgeType badge;
+
+  public static List<String> badgeToString(List<Badge> badges) {
+    return badges.stream()
+        .map(badge -> badge.getBadge().getDescription())
+        .collect(Collectors.toList());
+  }
 }
+

--- a/src/main/java/com/unity/goods/domain/member/entity/Member.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Member.java
@@ -74,6 +74,10 @@ public class Member extends BaseEntity {
   @OneToMany(mappedBy = "member")
   private List<Trade> tradeList  = new ArrayList<>();
 
+  @OneToMany(mappedBy = "member")
+  @Builder.Default
+  private List<Badge> badgeList = new ArrayList<>();
+
   public static Member fromSignUpRequest(SignUpRequest signUpRequest, String imageUrl) {
 
     return Member.builder()

--- a/src/main/java/com/unity/goods/domain/member/entity/Member.java
+++ b/src/main/java/com/unity/goods/domain/member/entity/Member.java
@@ -81,10 +81,7 @@ public class Member extends BaseEntity {
   private List<Wishlist> wishList = new ArrayList<>();
 
   @OneToMany(mappedBy = "member")
-  private List<Badge> badgeList = new ArrayList<>();
-
-  @OneToMany(mappedBy = "member")
-  private List<Trade> tradeList  = new ArrayList<>();
+  private List<Trade> tradeList = new ArrayList<>();
 
   @OneToMany(mappedBy = "member")
   @Builder.Default

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -22,6 +22,7 @@ import com.unity.goods.domain.member.dto.FindPasswordDto.FindPasswordRequest;
 import com.unity.goods.domain.member.dto.LoginDto;
 import com.unity.goods.domain.member.dto.MemberProfileDto.MemberProfileResponse;
 import com.unity.goods.domain.member.dto.ResignDto.ResignRequest;
+import com.unity.goods.domain.member.dto.SellerProfileDto.SellerProfileResponse;
 import com.unity.goods.domain.member.dto.SignUpDto.SignUpRequest;
 import com.unity.goods.domain.member.dto.SignUpDto.SignUpResponse;
 import com.unity.goods.domain.member.dto.UpdateProfileDto.UpdateProfileRequest;
@@ -298,6 +299,19 @@ public class MemberService {
     }
 
     return MemberProfileResponse.fromMember(findMember);
+  }
+
+  // 판매자 프로필 조회
+  public SellerProfileResponse getSellerProfile(Long sellerId) {
+
+    Member findMember = memberRepository.findById(sellerId)
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    if (findMember.getStatus() == RESIGN) {
+      throw new MemberException(RESIGNED_ACCOUNT);
+    }
+
+    return SellerProfileResponse.fromMember(findMember);
   }
 
   // 회원 프로필 수정

--- a/src/main/java/com/unity/goods/global/config/SecurityConfig.java
+++ b/src/main/java/com/unity/goods/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.unity.goods.global.config;
 
-import static org.springframework.http.HttpMethod.DELETE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
@@ -84,7 +83,8 @@ public class SecurityConfig {
         antMatcher(POST, "/api/member/signup"), // 회원가입
         antMatcher(POST, "/api/member/login"),  // 로그인
         antMatcher(POST, "/api/member/reissue"), // 토큰 재발급
-        antMatcher(GET,"/api/member/badge"), // 배지 조회
+        antMatcher(GET, "/api/member/badge"), // 배지 조회
+        antMatcher(GET, "/api/member/{sellerId}/profile"), // 판매자 정보 조회
         antMatcher(POST, "/api/email/**"), // 이메일 인증
         antMatcher(POST, "/api/goods/search"), // 검색
         antMatcher(GET, "/api/goods")
@@ -105,5 +105,5 @@ public class SecurityConfig {
     );
     return requestMatchers.toArray(RequestMatcher[]::new);
   }
-  
+
 }


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [X] 새로운 기능 추가
- [X] 코드 리팩토링

### 반영 브랜치
-  feat/goods-seller-info -> feat/goods

### 변경 사항

[**MemberController**] 
 - 회원, 비회원 모두 sellerId를 @PathVariable로 요청하여 판매자의 정보를 조회할 수 있습니다.
 
[**SellerProfileDto**] 
 - 판매자 정보 조회 요청의 응답값으로 판매자의 닉네임, 프로필이미지, 별점, 배지목록을 반환합니다.

 [**MemberService**]-[**getSellerProfile**] 
 - 탈퇴한 회원이 아닌경우 판매자의 정보를 조회할 수 있습니다.
 
 [**SecuriytConfig**] 
 - 회원/비회원 모두 조회 가능하도록 antMatcher을 등록해주었습니다.

### PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)