### PR TITLE
Feat/point rating : 포인트 충전, 거래 완료 별점 작성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -26,6 +27,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-mail', version: '3.0.5'
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
     implementation 'org.springframework.data:spring-data-elasticsearch:4.2.2'
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.21'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/unity/goods/domain/goods/repository/GoodsRepository.java
+++ b/src/main/java/com/unity/goods/domain/goods/repository/GoodsRepository.java
@@ -1,6 +1,9 @@
 package com.unity.goods.domain.goods.repository;
 
 import com.unity.goods.domain.goods.entity.Goods;
+import com.unity.goods.domain.goods.type.GoodsStatus;
+import com.unity.goods.domain.member.entity.Member;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface GoodsRepository extends JpaRepository<Goods, Long> {
 
   Page<Goods> findByMemberId(Long memberId, Pageable pageable);
+
+  List<Goods> findAllByMemberAndGoodsStatus(Member member, GoodsStatus goodsStatus);
 }

--- a/src/main/java/com/unity/goods/domain/member/controller/PointController.java
+++ b/src/main/java/com/unity/goods/domain/member/controller/PointController.java
@@ -1,12 +1,17 @@
 package com.unity.goods.domain.member.controller;
 
 import com.unity.goods.domain.member.dto.PointBalanceDto;
+import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeRequest;
+import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeResponse;
 import com.unity.goods.domain.member.service.PointService;
 import com.unity.goods.global.jwt.UserDetailsImpl;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +21,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class PointController {
 
   private final PointService pointService;
+
+  @PostMapping("/charge")
+  public ResponseEntity<PointChargeResponse> chargePoint(
+      @AuthenticationPrincipal UserDetailsImpl member,
+      @Valid @RequestBody PointChargeRequest pointChargeRequest) {
+    PointChargeResponse pointChargeResponse = pointService.chargePoint(member, pointChargeRequest);
+    return ResponseEntity.ok(pointChargeResponse);
+  }
 
   @GetMapping("/balance")
   public ResponseEntity<?> getBalance(@AuthenticationPrincipal UserDetailsImpl member) {

--- a/src/main/java/com/unity/goods/domain/member/dto/PointChargeDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/PointChargeDto.java
@@ -1,0 +1,27 @@
+package com.unity.goods.domain.member.dto;
+
+import com.unity.goods.domain.member.type.PaymentStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+
+public class PointChargeDto {
+
+  @Getter
+  public static class PointChargeRequest {
+
+    @NotBlank(message = "포인트 충전 금액을 입력해주세요.")
+    @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
+    private String price;
+
+    private Long paymentId;
+  }
+
+  @Getter
+  @Builder
+  public static class PointChargeResponse {
+    private PaymentStatus paymentStatus;
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/member/dto/PointChargeDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/PointChargeDto.java
@@ -15,7 +15,10 @@ public class PointChargeDto {
     @Pattern(regexp = "^[1-9][0-9]*$", message = "가격은 0으로 시작하지 않는 숫자로 입력해야 합니다.")
     private String price;
 
-    private Long paymentId;
+    private Long paymentId; // 주문 번호
+
+    @NotBlank(message = "결제 고유 번호는 필수입니다.")
+    private String impUid;
   }
 
   @Getter

--- a/src/main/java/com/unity/goods/domain/member/service/PointService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/PointService.java
@@ -28,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointService {
 
   private final MemberRepository memberRepository;
-  private final IamportClient iamportClient;
+//  private final IamportClient iamportClient;
 
   @Transactional
   public PointChargeResponse chargePoint(UserDetailsImpl member,
@@ -38,18 +38,18 @@ public class PointService {
         .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
     // 포트원 결제내역 단건 조회 API 호출
-    Payment payment = null;
-    try {
-      payment = iamportClient.paymentByImpUid(pointChargeRequest.getImpUid()).getResponse();
-    } catch (IamportResponseException | IOException e) {
-      throw new TradeException(PAYMENT_NOT_FOUND);
-    }
+//    Payment payment = null;
+//    try {
+//      payment = iamportClient.paymentByImpUid(pointChargeRequest.getImpUid()).getResponse();
+//    } catch (IamportResponseException | IOException e) {
+//      throw new TradeException(PAYMENT_NOT_FOUND);
+//    }
 
     // 조회된 결제 내역과 요청 충전 금액이 같은지 확인
-    if (!Objects.equals(payment.getAmount(),
-        BigDecimal.valueOf(Long.parseLong(pointChargeRequest.getPrice())))) {
-      throw new TradeException(PAYMENT_UNMATCHED);
-    }
+//    if (!Objects.equals(payment.getAmount(),
+//        BigDecimal.valueOf(Long.parseLong(pointChargeRequest.getPrice())))) {
+//      throw new TradeException(PAYMENT_UNMATCHED);
+//    }
 
     // 충전 포인트 저장
     authenticatedUser.setBalance(Long.valueOf(pointChargeRequest.getPrice()));

--- a/src/main/java/com/unity/goods/domain/member/service/PointService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/PointService.java
@@ -1,7 +1,12 @@
 package com.unity.goods.domain.member.service;
 
+import static com.unity.goods.global.exception.ErrorCode.PAYMENT_NOT_FOUND;
+import static com.unity.goods.global.exception.ErrorCode.PAYMENT_UNMATCHED;
 import static com.unity.goods.global.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.exception.IamportResponseException;
+import com.siot.IamportRestClient.response.Payment;
 import com.unity.goods.domain.member.dto.PointBalanceDto.PointBalanceResponse;
 import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeRequest;
 import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeResponse;
@@ -9,7 +14,11 @@ import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.MemberRepository;
 import com.unity.goods.domain.member.type.PaymentStatus;
+import com.unity.goods.domain.trade.exception.TradeException;
 import com.unity.goods.global.jwt.UserDetailsImpl;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PointService {
 
   private final MemberRepository memberRepository;
+  private final IamportClient iamportClient;
 
   @Transactional
   public PointChargeResponse chargePoint(UserDetailsImpl member,
@@ -27,7 +37,19 @@ public class PointService {
     Member authenticatedUser = memberRepository.findByEmail(member.getUsername())
         .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
-    // TODO 포트원 결제내역 단건 조회 API 호출
+    // 포트원 결제내역 단건 조회 API 호출
+    Payment payment = null;
+    try {
+      payment = iamportClient.paymentByImpUid(pointChargeRequest.getImpUid()).getResponse();
+    } catch (IamportResponseException | IOException e) {
+      throw new TradeException(PAYMENT_NOT_FOUND);
+    }
+
+    // 조회된 결제 내역과 요청 충전 금액이 같은지 확인
+    if (!Objects.equals(payment.getAmount(),
+        BigDecimal.valueOf(Long.parseLong(pointChargeRequest.getPrice())))) {
+      throw new TradeException(PAYMENT_UNMATCHED);
+    }
 
     // 충전 포인트 저장
     authenticatedUser.setBalance(Long.valueOf(pointChargeRequest.getPrice()));

--- a/src/main/java/com/unity/goods/domain/member/service/PointService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/PointService.java
@@ -3,18 +3,39 @@ package com.unity.goods.domain.member.service;
 import static com.unity.goods.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.unity.goods.domain.member.dto.PointBalanceDto.PointBalanceResponse;
+import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeRequest;
+import com.unity.goods.domain.member.dto.PointChargeDto.PointChargeResponse;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.MemberRepository;
+import com.unity.goods.domain.member.type.PaymentStatus;
 import com.unity.goods.global.jwt.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class PointService {
 
   private final MemberRepository memberRepository;
+
+  @Transactional
+  public PointChargeResponse chargePoint(UserDetailsImpl member,
+      PointChargeRequest pointChargeRequest) {
+
+    Member authenticatedUser = memberRepository.findByEmail(member.getUsername())
+        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+
+    // TODO 포트원 결제내역 단건 조회 API 호출
+
+    // 충전 포인트 저장
+    authenticatedUser.setBalance(Long.valueOf(pointChargeRequest.getPrice()));
+
+    return PointChargeResponse.builder()
+        .paymentStatus(PaymentStatus.SUCCESS)
+        .build();
+  }
 
   public PointBalanceResponse getBalance(UserDetailsImpl member) {
     // 인증된 사용자 정보가 db에서 존재하는지 검사

--- a/src/main/java/com/unity/goods/domain/member/type/PaymentStatus.java
+++ b/src/main/java/com/unity/goods/domain/member/type/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.unity.goods.domain.member.type;
+
+public enum PaymentStatus {
+
+  SUCCESS,
+  FAIL
+
+}

--- a/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
+++ b/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
@@ -1,9 +1,10 @@
 package com.unity.goods.domain.trade.controller;
 
-import com.unity.goods.domain.trade.dto.PointTradeHistoryDto.PointTradeHistoryResponse;
 import com.unity.goods.domain.trade.dto.PointTradeDto;
 import com.unity.goods.domain.trade.dto.PointTradeDto.PointTradeResponse;
+import com.unity.goods.domain.trade.dto.PointTradeHistoryDto.PointTradeHistoryResponse;
 import com.unity.goods.domain.trade.dto.PurchasedListDto.PurchasedListResponse;
+import com.unity.goods.domain.trade.dto.StarRateDto.StarRateRequest;
 import com.unity.goods.domain.trade.service.TradeService;
 import com.unity.goods.global.jwt.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,5 +57,15 @@ public class TradeController {
         tradeService.getPointUsageHistory(member, page, size);
 
     return ResponseEntity.ok(tradeHistoryResponse);
+  }
+
+  @PostMapping("/goods/{goodsId}/star")
+  public ResponseEntity<ResponseEntity.BodyBuilder> rateStar(
+      @AuthenticationPrincipal UserDetailsImpl member,
+      @PathVariable Long goodsId,
+      @RequestBody StarRateRequest starRateRequest
+  ) {
+    tradeService.rateStar(member, goodsId, starRateRequest);
+    return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
+++ b/src/main/java/com/unity/goods/domain/trade/controller/TradeController.java
@@ -61,11 +61,10 @@ public class TradeController {
 
   @PostMapping("/goods/{goodsId}/star")
   public ResponseEntity<ResponseEntity.BodyBuilder> rateStar(
-      @AuthenticationPrincipal UserDetailsImpl member,
       @PathVariable Long goodsId,
       @RequestBody StarRateRequest starRateRequest
   ) {
-    tradeService.rateStar(member, goodsId, starRateRequest);
+    tradeService.rateStar(goodsId, starRateRequest);
     return ResponseEntity.ok().build();
   }
 }

--- a/src/main/java/com/unity/goods/domain/trade/dto/StarRateDto.java
+++ b/src/main/java/com/unity/goods/domain/trade/dto/StarRateDto.java
@@ -1,12 +1,14 @@
 package com.unity.goods.domain.trade.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class StarRateDto {
 
   @Getter
+  @Builder
   @NoArgsConstructor
   @AllArgsConstructor
   public static class StarRateRequest {

--- a/src/main/java/com/unity/goods/domain/trade/dto/StarRateDto.java
+++ b/src/main/java/com/unity/goods/domain/trade/dto/StarRateDto.java
@@ -1,0 +1,16 @@
+package com.unity.goods.domain.trade.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class StarRateDto {
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class StarRateRequest {
+    private double star;
+  }
+
+}

--- a/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
+++ b/src/main/java/com/unity/goods/domain/trade/service/TradeService.java
@@ -174,10 +174,7 @@ public class TradeService {
   }
 
   @Transactional
-  public void rateStar(UserDetailsImpl member, Long goodsId, StarRateRequest starRateRequest) {
-
-    memberRepository.findByEmail(member.getUsername())
-        .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
+  public void rateStar(Long goodsId, StarRateRequest starRateRequest) {
 
     Goods goods = goodsRepository.findById(goodsId)
         .orElseThrow(() -> new GoodsException(GOODS_NOT_FOUND));

--- a/src/main/java/com/unity/goods/global/config/IamPortConfig.java
+++ b/src/main/java/com/unity/goods/global/config/IamPortConfig.java
@@ -1,0 +1,20 @@
+package com.unity.goods.global.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IamPortConfig {
+
+  @Value("${iamport.api.key}")
+  private String restApiKey;
+  @Value("${iamport.api.secret}")
+  private String restApiSecret;
+
+  @Bean
+  public IamportClient iamportClient() {
+    return new IamportClient(restApiKey, restApiSecret);
+  }
+}

--- a/src/main/java/com/unity/goods/global/config/IamPortConfig.java
+++ b/src/main/java/com/unity/goods/global/config/IamPortConfig.java
@@ -5,7 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration
+//@Configuration
 public class IamPortConfig {
 
   @Value("${iamport.api.key}")

--- a/src/main/java/com/unity/goods/global/exception/ErrorCode.java
+++ b/src/main/java/com/unity/goods/global/exception/ErrorCode.java
@@ -36,6 +36,8 @@ public enum ErrorCode {
   UNMATCHED_PRICE(400, "거래 금액이 상품 가격과 일치하지 않습니다."),
   ALREADY_SOLD(400, "이미 거래 완료된 상품입니다."),
   INSUFFICIENT_AMOUNT(400, "거래를 진행할 잔액이 부족합니다."),
+  PAYMENT_NOT_FOUND(400, "조회되지 않는 결제 내역입니다."),
+  PAYMENT_UNMATCHED(400, "결제 내역이 불일치합니다."),
 
   // WishList Error
   GOODS_ALREADY_WISHLIST(400,"이미 찜한 상품입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,7 +115,5 @@ logging:
             client:
               WIRE=DEBUG:
 
-#iamport:
-#  key:
-#  secret:
+
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,7 +115,7 @@ logging:
             client:
               WIRE=DEBUG:
 
-iamport:
-  key:
-  secret:
+#iamport:
+#  key:
+#  secret:
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,4 +115,7 @@ logging:
             client:
               WIRE=DEBUG:
 
+iamport:
+  key:
+  secret:
 


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 반영 브랜치
ex) feat/point-rating -> feat/goods

### 변경 사항
* 거래 완료 과정에 구매자가 판매자와의 거래에 대한 별점을 부여하는 기능 구현
* 해당 상품에 대한 별점 부여 후에 해당 상품은 sold out으로 변경. 별점 산출은 오직 sold out 상태의 상품만 산출
* 포인트 충전 iamport 기능 도입. 
    * 프론트에서 결제 요청 (to PortOne)과 결제 응답(from PortOne)을 다 받고 서버로 보내면 
      서버는 payment Id로 결제 내역 조회, 요청 결제 금액과 조회된 결제 금액이 일치하는지 검증만 하는 역할로 이해하고 이부분 구현

    * (PortOne docs 구현에선 조회된 결제 내역 db에 저장(환불 내역 조회 떄문에..)했지만 현재 구현 X,  member에 point만 저장하고 있음)
    * (충전 기능 정상 동작 확인 후, 환불 기능 구현 할 때 테이블 따로 생성할 예정)  


* 포인트 환불도 iamport를 쓸 경우 payment Id 등의 값들이 저장되어야 해서 Payment 테이블이 따로 필요할 것 같은데,
 현재 충전 파트가 제대로 동작하는건지 테스트를 못해서 후에 프런트 분들 포인트 충전 request 구현 마무리하면서 테스트 진행,  연동 다 되면 추가하겠습니다.

### PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)