### PR TITLE
Refactor: 거래비밀번호 관련 로직 수정

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - "main"
-      - "feat/goods"
+
   
 jobs:
   build:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - "main"
+      - "feat/goods"
 
   
 jobs:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
       - "main"
-      - "feat/goods"
 
   
 jobs:

--- a/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/MemberProfileDto.java
@@ -1,6 +1,7 @@
 package com.unity.goods.domain.member.dto;
 
 import static com.unity.goods.domain.member.entity.Badge.badgeToString;
+
 import com.unity.goods.domain.member.entity.Member;
 import java.util.List;
 import lombok.Builder;
@@ -16,21 +17,22 @@ public class MemberProfileDto {
     private String nickName;
     private String phoneNumber;
     private String profileImage;
+    private boolean tradePasswordExists;
     private double star;
     private List<String> badgeList;
 
-    public static MemberProfileResponse fromMember(Member member) {
+    public static MemberProfileResponse fromMember(Member member, boolean tradePasswordExists) {
 
       return MemberProfileResponse.builder()
           .memberId(member.getId())
           .nickName(member.getNickname())
           .phoneNumber(member.getPhoneNumber())
           .profileImage(member.getProfileImage())
+          .tradePasswordExists(tradePasswordExists)
           .star(member.getStar())
           .badgeList(badgeToString(member.getBadgeList()))
           .build();
     }
 
   }
-
 }

--- a/src/main/java/com/unity/goods/domain/member/dto/SignUpDto.java
+++ b/src/main/java/com/unity/goods/domain/member/dto/SignUpDto.java
@@ -33,7 +33,7 @@ public class SignUpDto {
 
     private String phoneNumber;
 
-    @Pattern(regexp = "^[0-9]{6}$", message = "거래 비밀번호는 6자리 숫자로 작성해주세요.")
+    @Pattern(regexp = "^$|^[0-9]{6}$", message = "거래 비밀번호는 6자리 숫자로 작성해주세요.")
     private String tradePassword;
 
   }
@@ -47,7 +47,7 @@ public class SignUpDto {
     private String nickName;
     private String phoneNumber;
 
-    public static SignUpResponse fromMember(Member member){
+    public static SignUpResponse fromMember(Member member) {
       return SignUpResponse.builder()
           .email(member.getEmail())
           .nickName(member.getNickname())

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -395,9 +395,11 @@ public class MemberService {
     Member findMember = memberRepository.findByEmail(member.getUsername())
         .orElseThrow(() -> new MemberException(USER_NOT_FOUND));
 
-    if (!passwordEncoder.matches(changeTradePasswordRequest.getCurTradePassword(),
-        findMember.getTradePassword())) {
-      throw new MemberException(PASSWORD_NOT_MATCH);
+    if (changeTradePasswordRequest.getCurTradePassword() != null) {
+      if (!passwordEncoder.matches(changeTradePasswordRequest.getCurTradePassword(),
+          findMember.getTradePassword())) {
+        throw new MemberException(PASSWORD_NOT_MATCH);
+      }
     }
 
     if (passwordEncoder.matches(changeTradePasswordRequest.getNewTradePassword(),

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -300,7 +300,9 @@ public class MemberService {
       throw new MemberException(RESIGNED_ACCOUNT);
     }
 
-    return MemberProfileResponse.fromMember(findMember);
+    boolean tradePasswordExists = findMember.getTradePassword() != null;
+
+    return MemberProfileResponse.fromMember(findMember, tradePasswordExists);
   }
 
   // 판매자 프로필 조회
@@ -353,7 +355,8 @@ public class MemberService {
     return UpdateProfileResponse.fromMember(findMember);
   }
 
-  private String uploadProfileImageToS3(UserDetailsImpl member, UpdateProfileRequest updateProfileRequest) {
+  private String uploadProfileImageToS3(UserDetailsImpl member,
+      UpdateProfileRequest updateProfileRequest) {
     String uploadedUrl = s3Service.uploadFile(updateProfileRequest.getProfileImageFile(),
         member.getUsername() + "/" + "profileImage");
     log.info("[updateMemberProfile] : {} 프로필 이미지 업로드 완료", member.getUsername());

--- a/src/main/java/com/unity/goods/domain/member/service/MemberService.java
+++ b/src/main/java/com/unity/goods/domain/member/service/MemberService.java
@@ -27,12 +27,10 @@ import com.unity.goods.domain.member.dto.SignUpDto.SignUpRequest;
 import com.unity.goods.domain.member.dto.SignUpDto.SignUpResponse;
 import com.unity.goods.domain.member.dto.UpdateProfileDto.UpdateProfileRequest;
 import com.unity.goods.domain.member.dto.UpdateProfileDto.UpdateProfileResponse;
-import com.unity.goods.domain.member.entity.Badge;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.member.exception.MemberException;
 import com.unity.goods.domain.member.repository.BadgeRepository;
 import com.unity.goods.domain.member.repository.MemberRepository;
-import com.unity.goods.domain.member.type.BadgeType;
 import com.unity.goods.domain.model.TokenDto;
 import com.unity.goods.global.jwt.JwtTokenProvider;
 import com.unity.goods.global.jwt.UserDetailsImpl;
@@ -40,7 +38,6 @@ import com.unity.goods.infra.service.RedisService;
 import com.unity.goods.infra.service.S3Service;
 import java.security.SecureRandom;
 import java.util.Date;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -98,7 +95,12 @@ public class MemberService {
 
     // 비밀번호 & 거래 비밀번호 암호화
     signUpRequest.setPassword(passwordEncoder.encode(signUpRequest.getPassword()));
-    signUpRequest.setTradePassword(passwordEncoder.encode(signUpRequest.getTradePassword()));
+    if (!signUpRequest.getTradePassword().isEmpty()) {
+      signUpRequest.setTradePassword(passwordEncoder.encode(signUpRequest.getTradePassword()));
+    } else {
+      signUpRequest.setTradePassword(null);
+    }
+
     Member member = Member.fromSignUpRequest(signUpRequest, imageUrl);
     memberRepository.save(member);
 


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)

- [x] 코드 리팩토링

### 반영 브랜치
ex) refactor/trade-password -> feat/goods

### 변경 사항
[**MemberProfileDto**] 
 - 거래비밀번호 설정 여부를 확인하기 위해 tradePasswordExists boolean 필드를 추가하고, 
 프로필 조회시 응답값에 추가했습니다.

[**SignUpDto**] 
- 회원가입시 거래비밀번호 설정을 선택사항으로 변경하고, 설정하지 않을 시 요청값으로 빈문자열을 받습니다.

[**MemberProfileDto**] 
 - 거래비밀번호 설정 여부를 확인하기 위해 tradePasswordExists boolean 필드를 추가하고, 
 프로필 조회시 응답값에 추가했습니다.

[**MemberService**] [**signUp**]
- 회원가입시 거래비밀번호를 설정하지 않았을 경우를 검증하는 로직을 추가했습니다.

[**MemberService**] [**getMemberProfile**]
- 프로필을 조회할 때 거래비밀번호 여부를 확인하는 로직을 추가했습니다.

[**MemberService**] [**changeTradePassword**]
- 거래비밀번호를 변경할 때 기존에 거래비밀번호를 설정했는지 여부에 따라 거래비밀번호를 수정하도록 했습니다.

### PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)