### PR TITLE
Fix: 외래키 제약 조건으로 인해 매핑된 엔티티를 삭제하지 못하는 버그 수정

### DIFF
--- a/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
+++ b/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
@@ -71,11 +71,11 @@ public class Goods extends BaseEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
-  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.REMOVE)
   @Builder.Default
   private List<Image> imageList = new ArrayList<>();
 
-  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.REMOVE)
   @Builder.Default
   private List<Wishlist> wishList = new ArrayList<>();
 
@@ -83,7 +83,7 @@ public class Goods extends BaseEntity {
   @Builder.Default
   private List<Trade> tradeList = new ArrayList<>();
 
-  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.REMOVE)
   @Builder.Default
   private List<ChatRoom> chatRoomList = new ArrayList<>();
 

--- a/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
+++ b/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
@@ -8,6 +8,7 @@ import com.unity.goods.domain.goods.type.GoodsStatus;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.model.BaseEntity;
 import com.unity.goods.domain.trade.entity.Trade;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -70,11 +71,11 @@ public class Goods extends BaseEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
-  @OneToMany(mappedBy = "goods")
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
   @Builder.Default
   private List<Image> imageList = new ArrayList<>();
 
-  @OneToMany(mappedBy = "goods")
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
   @Builder.Default
   private List<Wishlist> wishList = new ArrayList<>();
 
@@ -82,7 +83,7 @@ public class Goods extends BaseEntity {
   @Builder.Default
   private List<Trade> tradeList = new ArrayList<>();
 
-  @OneToMany(mappedBy = "goods")
+  @OneToMany(mappedBy = "goods", cascade = CascadeType.ALL)
   @Builder.Default
   private List<ChatRoom> chatRoomList = new ArrayList<>();
 

--- a/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
+++ b/src/main/java/com/unity/goods/domain/goods/entity/Goods.java
@@ -2,8 +2,8 @@ package com.unity.goods.domain.goods.entity;
 
 import static com.unity.goods.domain.goods.type.GoodsStatus.SALE;
 
+import com.unity.goods.domain.chat.entity.ChatRoom;
 import com.unity.goods.domain.goods.dto.UploadGoodsDto.UploadGoodsRequest;
-import com.unity.goods.domain.goods.dto.WishlistDto;
 import com.unity.goods.domain.goods.type.GoodsStatus;
 import com.unity.goods.domain.member.entity.Member;
 import com.unity.goods.domain.model.BaseEntity;
@@ -80,7 +80,11 @@ public class Goods extends BaseEntity {
 
   @OneToMany(mappedBy = "goods")
   @Builder.Default
-  private List<Trade> tradeList  = new ArrayList<>();
+  private List<Trade> tradeList = new ArrayList<>();
+
+  @OneToMany(mappedBy = "goods")
+  @Builder.Default
+  private List<ChatRoom> chatRoomList = new ArrayList<>();
 
   public static Goods fromUploadGoodsRequest(UploadGoodsRequest request) {
 


### PR DESCRIPTION
### PR 유형(어떤 변경 사항이 있나요?)
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링

### 반영 브랜치
ex) fix/delete-goods-> feat/goods

### 변경 사항
[**Goods**]
- ChatRoom 과 양방향 매핑 누락된 부분 추가했습니다.
- 외래키 제약 조건으로 인해 Goods의 외래키를 가진 ChatRoom, Image, WishList 가 존재하는 경우
  해당  Goods를 삭제할 수 없는 버그를 수정하기 위해 Goods가 삭제될 때 함께 삭제 되도록 Cascade.REMOVE 조건을
  추가했습니다.

### PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)